### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2,6 +2,17 @@
 // Exports: App
 
 export const App = (() => {
+  // Escapes HTML special characters in a string
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;')
+      .replace(/`/g, '&#96;');
+  }
+
   let Algorithms, Storage, Charts;
   let project = null;
   
@@ -385,7 +396,7 @@ export const App = (() => {
       });
       
       // header
-      const cols = catLabels.map(l => `<th>${l}</th>`).join('');
+      const cols = catLabels.map(l => `<th>${escapeHtml(l)}</th>`).join('');
       head.innerHTML = `<tr><th>Hypothesis</th>${cols}</tr>`;
       
       // rows - preserve existing values when rebuilding
@@ -401,9 +412,9 @@ export const App = (() => {
         const tr = document.createElement('tr');
         const cells = catLabels.map((catLabel, cIdx) => {
           const existingVal = existingValues[hIdx] && existingValues[hIdx][cIdx] ? existingValues[hIdx][cIdx] : '';
-          return `<td><input type="text" value="${existingVal}" aria-label="P(${catLabel}|${h.label})" placeholder="0.5"></td>`;
+          return `<td><input type="text" value="${escapeHtml(existingVal)}" aria-label="P(${escapeHtml(catLabel)}|${escapeHtml(h.label)})" placeholder="0.5"></td>`;
         }).join('');
-        tr.innerHTML = `<td>${h.label}</td>${cells}`;
+        tr.innerHTML = `<td>${escapeHtml(h.label)}</td>${cells}`;
         body.appendChild(tr);
       }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/SentinelArchivist/bayes/security/code-scanning/5](https://github.com/SentinelArchivist/bayes/security/code-scanning/5)

The best way to fix this problem is to ensure that all user-controlled text values are properly escaped before being interpolated into strings that will be set via `.innerHTML`. Escaping can be done by encoding special HTML characters (`&`, `<`, `>`, `"`, `'`, `` ` ``) to their corresponding HTML entities, so user input is always interpreted as plain text, not as markup or script.

We'll implement a lightweight HTML-escaping function (since this is a common need and no general-purpose escaping function appears to exist in the shown code). We will then use this function to wrap all interpolations of user data in template literals destined for `innerHTML` (specifically in lines 388, 404, and 406).

Required changes:
- Add a function `escapeHtml(str)` to the top of the module (within the provided code).
- Use this function to wrap all instances of `${l}`, `${catLabel}`, `${h.label}`, and `${existingVal}` that are inserted into HTML code via template strings assigned to `.innerHTML`.

No new methods or external libraries are strictly necessary: a small utility function suffices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
