### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -331,6 +331,16 @@ export const App = (() => {
 
   // ---------- Evidence: Jeffrey ----------
   function renderEvidenceJeffrey() {
+    // Escapes &, <, >, ", ', /
+    function escapeHTML(str) {
+      return String(str)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;")
+        .replace(/\//g, "&#x2F;");
+    }
     const catsBody = document.getElementById('jeffrey-cats');
     const head = document.getElementById('jeffrey-like-head');
     const body = document.getElementById('jeffrey-like-body');
@@ -385,7 +395,7 @@ export const App = (() => {
       });
       
       // header
-      const cols = catLabels.map(l => `<th>${l}</th>`).join('');
+      const cols = catLabels.map(l => `<th>${escapeHTML(l)}</th>`).join('');
       head.innerHTML = `<tr><th>Hypothesis</th>${cols}</tr>`;
       
       // rows - preserve existing values when rebuilding
@@ -401,9 +411,9 @@ export const App = (() => {
         const tr = document.createElement('tr');
         const cells = catLabels.map((catLabel, cIdx) => {
           const existingVal = existingValues[hIdx] && existingValues[hIdx][cIdx] ? existingValues[hIdx][cIdx] : '';
-          return `<td><input type="text" value="${existingVal}" aria-label="P(${catLabel}|${h.label})" placeholder="0.5"></td>`;
+          return `<td><input type="text" value="${existingVal}" aria-label="P(${escapeHTML(catLabel)}|${escapeHTML(h.label)})" placeholder="0.5"></td>`;
         }).join('');
-        tr.innerHTML = `<td>${h.label}</td>${cells}`;
+        tr.innerHTML = `<td>${escapeHTML(h.label)}</td>${cells}`;
         body.appendChild(tr);
       }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/SentinelArchivist/bayes/security/code-scanning/4](https://github.com/SentinelArchivist/bayes/security/code-scanning/4)

To fix the issue, all dynamic data (in this case, category labels entered by users, namely `l` in `catLabels.map(l => ...)`) should be escaped before placing it into HTML markup via `.innerHTML`. This requires a function that escapes HTML special characters (`&`, `<`, `>`, `"`, `'`, and `/`) in user-provided strings. The best option is to define a small HTML-escape function within this scope and call it on all data injected into HTML strings.

Specifically:
- Define an escape function, e.g., `escapeHTML`.
- Use this function when building the table header (line 388, `cols`) and when building the input `aria-label` (line 404) and the hypothesis label cell (line 406), as these may display user-provided data.
- Only change the relevant lines, do not alter logic or layout.

No new dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
