### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/test_h1_visibility.html
+++ b/test_h1_visibility.html
@@ -122,12 +122,21 @@
             debugDiv.scrollTop = debugDiv.scrollHeight;
         }
 
+        function escapeHtml(string) {
+            return String(string)
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&#39;");
+        }
+
         function addTestResult(testName, passed, message) {
             testResults.push({ testName, passed, message });
             const resultsDiv = document.getElementById('test-results');
             const resultDiv = document.createElement('div');
             resultDiv.className = `test-result ${passed ? 'pass' : 'fail'}`;
-            resultDiv.innerHTML = `<strong>${testName}:</strong> ${passed ? 'PASS' : 'FAIL'} - ${message}`;
+            resultDiv.innerHTML = `<strong>${escapeHtml(testName)}:</strong> ${passed ? 'PASS' : 'FAIL'} - ${escapeHtml(message)}`;
             resultsDiv.appendChild(resultDiv);
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/SentinelArchivist/bayes/security/code-scanning/3](https://github.com/SentinelArchivist/bayes/security/code-scanning/3)

To fix the vulnerability, we must ensure that untrusted text like `message` is properly escaped before being rendered in `innerHTML`. The best fix is to explicitly escape (HTML encode) any user-generated content interpolated into HTML strings before assignment to `innerHTML`. In this snippet, both `testName` and `message` could conceivably be tainted, but the concrete taint is only with `message`. We need an HTML escape utility, and to apply it when interpolating into `innerHTML`.  

Steps:
1. Define a function (in the `<script>` block) to HTML-escape strings, e.g. `escapeHtml`.
2. Use this function when inserting `message` and `testName` into the string passed to `innerHTML` in line 130.
3. No third-party libraries are necessary; custom escaping is acceptable for this context.

All changes are focused around the JavaScript in the provided snippet in test_h1_visibility.html.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
