### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/test_fix.html
+++ b/test_fix.html
@@ -96,13 +96,26 @@
         import { Charts } from './js/charts.js';
         import { App } from './js/app.js';
 
+        // Escape HTML to prevent XSS when inserting DOM text as HTML
+        function escapeHTML(str) {
+            return str.replace(/[&<>"']/g, function (char) {
+                switch (char) {
+                    case "&": return "&amp;";
+                    case "<": return "&lt;";
+                    case ">": return "&gt;";
+                    case '"': return "&quot;";
+                    case "'": return "&#39;";
+                }
+            });
+        }
+
         const testOutput = document.getElementById('test-output');
         const rerunBtn = document.getElementById('rerun-test');
 
         function log(type, message) {
             const div = document.createElement('div');
             div.className = `test-${type}`;
-            div.innerHTML = `<strong>[${type.toUpperCase()}]</strong> ${message}`;
+            div.innerHTML = `<strong>[${type.toUpperCase()}]</strong> ${escapeHTML(message)}`;
             testOutput.appendChild(div);
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/SentinelArchivist/bayes/security/code-scanning/2](https://github.com/SentinelArchivist/bayes/security/code-scanning/2)

To fix the problem, the code must ensure that any user-supplied or DOM-sourced text (here, `message`) is safely encoded before inserting it into the DOM as HTML. The best way is to escape HTML special characters (e.g., `<`, `>`, `&`, `"`, `'`) in `message` before embedding it into an HTML string assigned to innerHTML. The most robust implementation involves writing a simple escaping function (since imports are restricted to well-known client-side libraries, but none are imported here), or using the browser's built-in APIs.

For this code snippet in `test_fix.html`, the optimal fix is to escape the `message` string before inclusion in the innerHTML. One practical way (using browser APIs, without adding dependencies) is to set the HTML for the `div` to include the `<strong>[...]</strong>`, then set the message as a text node (or assign escaped text as part of the string). Example: create the `strong` element separately, then append a text node with `message`. Alternatively, define an `escapeHTML` function and use it to encode `message`.

You should:
- Add an `escapeHTML` helper function near the top of the script block.
- Change line 105 to use `${escapeHTML(message)}` instead of `${message}`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
