### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/debug_comprehensive.html
+++ b/debug_comprehensive.html
@@ -117,6 +117,16 @@
             analysis.innerHTML = html;
         }
 
+        // Escapes HTML special characters in a string to prevent XSS
+        function escapeHtml(str) {
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
         function analyzeDOMStructure() {
             const analysis = document.getElementById('dom-analysis');
             const hypoRows = document.getElementById('hypo-rows');
@@ -147,7 +157,7 @@
                         const rowButtons = row.querySelectorAll('button');
                         const hypothesisId = row.getAttribute('data-hypothesis-id');
                         
-                        html += `<div>Row ${i}: ID="${hypothesisId}", Inputs=${rowInputs.length}, Buttons=${rowButtons.length}</div>`;
+                        html += `<div>Row ${i}: ID="${escapeHtml(hypothesisId)}", Inputs=${rowInputs.length}, Buttons=${rowButtons.length}</div>`;
                         
                         if (rowInputs.length >= 2) {
                             html += `<div>  - Label: "${rowInputs[0].value}", Prior: "${rowInputs[1].value}"</div>`;


### PR DESCRIPTION
Potential fix for [https://github.com/SentinelArchivist/bayes/security/code-scanning/1](https://github.com/SentinelArchivist/bayes/security/code-scanning/1)

To fix this vulnerability, ensure that any data originating from the DOM (in this case, the `data-hypothesis-id` attribute) is properly escaped before being interpolated into HTML content that will later be inserted via `innerHTML`. The escaping should encode special HTML characters (`<`, `>`, `"`, `'`, `&`) so that even if they are supplied by an attacker, they will be rendered harmlessly as text.

The best approach is to define a simple HTML escaping function (e.g., `escapeHtml`) and apply it to any untrusted values before placing them in the interpolated HTML string. The updated block will ensure that `hypothesisId` is escaped in the corresponding output.

All required edits are in `debug_comprehensive.html`, in (inside) the `analyzeDOMStructure` function:
- Insert a safe HTML-escaping utility function in the script (if not present).
- Use this function to escape `hypothesisId` before interpolation into the HTML template string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
