### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/debug_comprehensive.html
+++ b/debug_comprehensive.html
@@ -160,7 +160,7 @@
                         html += `<div>Row ${i}: ID="${escapeHtml(hypothesisId)}", Inputs=${rowInputs.length}, Buttons=${rowButtons.length}</div>`;
                         
                         if (rowInputs.length >= 2) {
-                            html += `<div>  - Label: "${rowInputs[0].value}", Prior: "${rowInputs[1].value}"</div>`;
+                            html += `<div>  - Label: "${escapeHtml(rowInputs[0].value)}", Prior: "${escapeHtml(rowInputs[1].value)}"</div>`;
                         }
                     });
                 }


### PR DESCRIPTION
Potential fix for [https://github.com/SentinelArchivist/bayes/security/code-scanning/1](https://github.com/SentinelArchivist/bayes/security/code-scanning/1)

To fix this vulnerability, we need to ensure any potentially unsafe string interpolated into HTML via `innerHTML` is properly escaped to prevent untrusted data from being interpreted as HTML.  
Specifically, on line 163 in `debug_comprehensive.html`, we should pass both `rowInputs[0].value` (label) and `rowInputs[1].value` (prior) through the existing `escapeHtml` function before embedding them in the HTML string.  
The required change is to update line 163 (and any similar instances) to use `escapeHtml(rowInputs[0].value)` and `escapeHtml(rowInputs[1].value)` for secure contextual output encoding.  
No new imports or dependencies are required, since the `escapeHtml` function is already referenced and presumably defined elsewhere in the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
